### PR TITLE
Change composer type to "wordpress-plugin"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "timber/timber",
-  "type": "library",
+  "type": "wordpress-plugin",
   "description": "Plugin to write WordPress themes w Object-Oriented Code and the Twig Template Engine",
   "keywords": [
     "timber",


### PR DESCRIPTION
**Ticket**: #979

#### Issue
Using Timber library with composer, not by the classic WordPress way.


#### Solution
The solution is quite simple: changing the Timber's composer type allow us to install Timber in the right folder. By setting the type to "wordpress-plugin", Timber will be installed by default in the `WP_CONTENTS/plugins` folder.

This solution allow us to set a custom path to Timber too. For example, in [Olympus](https://github.com/GetOlympus/Olympus), Timber will be installed in `WP_CONTENTS/mu-plugins` and will be loaded automatically.


#### Impact
No impact for installed repository. But a better integration for the next one.


#### Usage
Nothing I guess.


#### Considerations
I am really supporting you, so please, continue to make our themes awesome :)
You can easily improve Timber by making a non-plugin version which can be used and autoloaded in a WordPress framework.


#### Testing
Just do the `composer install` command once in a new (Bedrock|Olympus|Whatever) project.